### PR TITLE
Fix "NullReferenceException" in Batch Conversion

### DIFF
--- a/HEIF Utility English/Batch Conversion.cs
+++ b/HEIF Utility English/Batch Conversion.cs
@@ -23,11 +23,12 @@ namespace HEIF_Utility
 
         public Batch_Conversion()
         {
+            filelist = new HEIF_Utility.Batch_Conversion.ListViewWithoutScrollBar();
+
             InitializeComponent();
 
-            filelist = new HEIF_Utility.Batch_Conversion.ListViewWithoutScrollBar();
             FilelistPanel.Controls.Add(filelist);
-            
+
             //set filelist property
             filelist.Dock = DockStyle.Fill;
             filelist.AllowColumnReorder = false;

--- a/HEIF Utility/Batch Conversion.cs
+++ b/HEIF Utility/Batch Conversion.cs
@@ -23,9 +23,10 @@ namespace HEIF_Utility
 
         public Batch_Conversion()
         {
-            InitializeComponent();
-
             filelist = new HEIF_Utility.Batch_Conversion.ListViewWithoutScrollBar();
+
+            InitializeComponent();
+            
             FilelistPanel.Controls.Add(filelist);
 
             //set filelist property


### PR DESCRIPTION
Remove the instantiation to the front of event initialization to avoid
'NullReferenceException'